### PR TITLE
[WIP] Skeleton implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,14 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "tslint -t stylish --project \"tsconfig.json\""
+    "lint": "tslint -t stylish --project \"tsconfig.json\"",
+    "build": "tsc"
   },
   "author": "mziccard@redhat.com",
   "license": "Apache-2.0",
+  "bin": {
+    "kubectl-ag": "./lib/index.js"
+  },
   "engines": {
     "node": "12.10.0"
   }

--- a/src/cmds/app-cmds/app-delete.ts
+++ b/src/cmds/app-cmds/app-delete.ts
@@ -1,0 +1,14 @@
+import { Arguments } from 'yargs';
+import { AbstractNamespaceScopedCommand, expose } from '../command-interface';
+
+class AppDeleteCommand extends AbstractNamespaceScopedCommand {
+  constructor() {
+    super('delete', 'Deletes a mobile client');
+  }
+  public handler(yargs: Arguments) {
+    //TODO: add here the real code
+    console.log('app delete called - namespace:', yargs.namespace);
+  }
+}
+
+expose(new AppDeleteCommand(), module);

--- a/src/cmds/app-cmds/app-gen.ts
+++ b/src/cmds/app-cmds/app-gen.ts
@@ -1,0 +1,14 @@
+import { Arguments } from 'yargs';
+import { AbstractCommand, expose } from '../command-interface';
+
+class AppGenCommand extends AbstractCommand {
+  constructor() {
+    super('gen', 'Generates/updates the mobile-services.json file');
+  }
+  public handler(yargs: Arguments) {
+    //TODO: add here the real code
+    console.log('app gen called');
+  }
+}
+
+expose(new AppGenCommand(), module);

--- a/src/cmds/app-cmds/app-init.ts
+++ b/src/cmds/app-cmds/app-init.ts
@@ -1,12 +1,22 @@
-import { Argv } from 'yargs';
-import { CliCommand, publish } from '../command-interface';
+import { Arguments, Argv } from 'yargs';
+import { AbstractNamespaceScopedCommand, expose } from '../command-interface';
 
-class AppInitCommand implements CliCommand {
-  public name: string = 'init';
-  public desc: string = 'Initialize a new app';
-  public handler(yargs: Argv) {
+class AppInitCommand extends AbstractNamespaceScopedCommand {
+  constructor() {
+    super('init <name>', 'Initialize a new app');
+  }
+
+  protected initCli(yargs: Argv): Argv {
+    return yargs.positional('name', {
+      describe: 'the name of the app to be created',
+      type: 'string',
+    });
+  }
+
+  public handler(yargs: Arguments) {
+    //TODO: add here the real code
     console.log('app init called');
   }
 }
 
-publish(new AppInitCommand(), module);
+expose(new AppInitCommand(), module);

--- a/src/cmds/app-cmds/app-list.ts
+++ b/src/cmds/app-cmds/app-list.ts
@@ -1,0 +1,17 @@
+import { Arguments } from 'yargs';
+import { AbstractNamespaceScopedCommand, expose } from '../command-interface';
+
+class AppListCommand extends AbstractNamespaceScopedCommand {
+  constructor() {
+    super(
+      'list',
+      "Lists all mobile client in a namespace (default 'mobile-developer-console')",
+    );
+  }
+  public handler(yargs: Arguments) {
+    //TODO: add here the real code
+    console.log('app list called - namespace:', yargs.namespace);
+  }
+}
+
+expose(new AppListCommand(), module);

--- a/src/cmds/command-interface.ts
+++ b/src/cmds/command-interface.ts
@@ -1,14 +1,83 @@
-import { Argv } from 'yargs';
+import { Argv, Arguments } from 'yargs';
 
-export interface CliCommand {
-  name: string;
-  desc: string;
-  handler?(yargs: Argv): void;
-  builder?(yargs: Argv): void;
+/**
+ * Interface to be implemented by all the commands.
+ */
+export interface CommandInterface {
+  /**
+   * The name of the command. This will appear in the command line.
+   */
+  readonly name: string;
+  /**
+   * A description of what the command does. This will be used to generate an help screen.
+   */
+  readonly desc: string;
+
+  /**
+   * This function will be called when the command is invoked from the command line.
+   * If omitted, then the command must be a container for other subcommands.
+   * @param yargs
+   */
+  handler?(yargs: Arguments): void;
+
+  /**
+   * Configure the yargs command line parser.
+   * @param yargs
+   */
+  builder?(yargs: Argv): Argv;
 }
 
+/**
+ * Base class for commands.
+ */
+export abstract class AbstractCommand implements CommandInterface {
+  readonly name: string;
+  readonly desc: string;
+
+  constructor(name: string, desc: string) {
+    this.name = name;
+    this.desc = desc;
+  }
+}
+
+/**
+ * Most of the commands will be namespace scoped. Extending this class, the command will get the '-n|--namespace' option.
+ */
+export abstract class AbstractNamespaceScopedCommand extends AbstractCommand {
+  /**
+   * Implement this method to configure the yarg parser. No need to add the '-n|--namespace'.
+   * @param yargs
+   */
+  protected initCli?(yargs: Argv): Argv;
+
+  private initYargs(yargs: Argv): Argv {
+    return yargs
+      .option('namespace', {
+        alias: 'n',
+        type: 'string',
+        describe: 'namespace',
+        default: 'mobile-developer-console',
+        demand: true,
+      })
+      .help();
+  }
+
+  public readonly builder = (yargs: Argv) => {
+    if (this.initCli) {
+      return this.initCli(this.initYargs(yargs));
+    } else {
+      return this.initYargs(yargs);
+    }
+  };
+}
+
+/**
+ * This method must be called to expose the command to yargs.
+ * @param cliCommand - the command to be exposed
+ * @param commandModule - the module containing the command
+ */
 // tslint:disable-next-line: no-any
-export function publish(cliCommand: CliCommand, commandModule: any) {
+export function expose(cliCommand: CommandInterface, commandModule: any) {
   commandModule.exports.command = cliCommand.name;
   commandModule.exports.desc = cliCommand.desc;
 

--- a/src/cmds/push.ts
+++ b/src/cmds/push.ts
@@ -1,0 +1,9 @@
+import { AbstractNamespaceScopedCommand, expose } from './command-interface';
+
+class PushCommand extends AbstractNamespaceScopedCommand {
+  constructor() {
+    super('push', 'Pushes all local resources in .ag folder into a namespace');
+  }
+}
+
+expose(new PushCommand(), module);

--- a/src/cmds/service-cmds/service-delete.ts
+++ b/src/cmds/service-cmds/service-delete.ts
@@ -1,0 +1,17 @@
+import { Arguments } from 'yargs';
+import { AbstractCommand, expose } from '../command-interface';
+
+class ServiceDeleteCommand extends AbstractCommand {
+  constructor() {
+    super(
+      'delete',
+      'Deletes a service binding from a mobile client using the local mobile client resource as reference.',
+    );
+  }
+  public handler(yargs: Arguments) {
+    //TODO: add here the real code
+    console.log('service delete called - namespace:', yargs.namespace);
+  }
+}
+
+expose(new ServiceDeleteCommand(), module);

--- a/src/cmds/service-cmds/service-list.ts
+++ b/src/cmds/service-cmds/service-list.ts
@@ -1,0 +1,14 @@
+import { Arguments } from 'yargs';
+import { AbstractCommand, expose } from '../command-interface';
+
+class ServiceListCommand extends AbstractCommand {
+  constructor() {
+    super('list', 'List all available mobile services');
+  }
+  public handler(yargs: Arguments) {
+    //TODO: add here the real code
+    console.log('service list called - namespace:', yargs.namespace);
+  }
+}
+
+expose(new ServiceListCommand(), module);

--- a/src/cmds/service.ts
+++ b/src/cmds/service.ts
@@ -2,16 +2,16 @@ import { Argv } from 'yargs';
 
 import { CommandInterface, expose } from './command-interface';
 
-class AppCommand implements CommandInterface {
-  public name: string = 'app';
-  public desc: string = 'Manages applications';
+class ServiceCommand implements CommandInterface {
+  public name: string = 'service';
+  public desc: string = 'Handles mobile services';
   public builder(yargs: Argv) {
     // tslint:disable-next-line: no-unused-expression
     return yargs
-      .commandDir('app-cmds')
+      .commandDir('service-cmds')
       .demandCommand()
       .help();
   }
 }
 
-expose(new AppCommand(), module);
+expose(new ServiceCommand(), module);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
+#!/usr/bin/env node
 import * as yargs from 'yargs';
 
 // tslint:disable-next-line: no-unused-expression
 yargs
-  .strict()
   .commandDir('cmds')
   .demandCommand()
+  .strict()
   .help()
   .version().argv;


### PR DESCRIPTION
## Motivation
Provide a skeleton implementation with some structure to give some rule and some base class for adding new commands.

## Verify

1. Clone this repo.
1. Run `npm run build && npm link`
2. Run the command as `kubectl-ag`
3. Verify that it is correctly caught by `kubectl` by running it as `kubectl ag`

### Expected outputs (I will show here only the app command)
#### kubectl ag
```
kubectl-ag <command>

Commands:
  kubectl-ag app      Manages applications
  kubectl-ag push     Pushes all local resources in .ag folder into a namespace
  kubectl-ag service  Handles mobile services

Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]
```

#### kubectl ag app
```
kubectl-ag app

Manages applications

Commands:
  kubectl-ag app delete  Deletes a mobile client
  kubectl-ag app gen     Generates/updates the mobile-services.json file
  kubectl-ag app init    Initialize a new app
  kubectl-ag app list    Lists all mobile client in a namespace (default
                         'mobile-developer-console')

Options:
  --version  Show version number                                       [boolean]
  --help     Show help                                                 [boolean]

Not enough non-option arguments: got 0, need at least 1
```
#### kubectl ag app init
```
app init called
```

