### PR TITLE
Added Datasync binding support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "figlet": "1.2.4",
     "fs-extra": "8.1.0",
     "inquirer": "7.0.0",
-    "json-data-validator": "^0.3.1",
+    "json-data-validator": "^0.3.2",
     "kubernetes-client": "8.3.4",
     "ora": "3.4.0",
     "uuid": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "figlet": "1.2.4",
     "fs-extra": "8.1.0",
     "inquirer": "7.0.0",
+    "json-data-validator": "^0.3.1",
     "kubernetes-client": "8.3.4",
     "ora": "3.4.0",
     "uuid": "3.3.3",

--- a/src/cmds/service-cmds/service-bind.ts
+++ b/src/cmds/service-cmds/service-bind.ts
@@ -43,7 +43,7 @@ class ServiceBindCliCommand extends AbstractNamespaceScopedCommand {
       (yargs.namespace as string) ||
       KubeClient.getInstance().getCurrentNamespace();
     const res = await KubeClient.getInstance().execute(
-      new AgKubePushBindingCommand(namespace, name, ''),
+      new AgKubePushBindingCommand(namespace, name, yargs.conf as string),
     );
     console.log(res);
   };

--- a/src/cmds/service-cmds/service-bind.ts
+++ b/src/cmds/service-cmds/service-bind.ts
@@ -10,7 +10,6 @@ import {
 } from '../../utils/KubeClient/commands/Observer';
 import { ora } from '../../utils/spinner/OraSingleton';
 import { Spinner } from '../../utils/spinner';
-import { KubeCommand } from '../../utils/KubeClient/KubeClient';
 import { AgKubeDataSyncBindingCommand } from '../../utils/KubeClient/commands/AgKubeDataSyncBindingCommand';
 import { AbstractKubeCommand } from '../../utils/KubeClient/commands/AbstractKubeCommand';
 
@@ -85,6 +84,10 @@ class ServiceBindCliCommand extends AbstractNamespaceScopedCommand
           appname,
           JSON.parse(conf),
         );
+      default:
+        throw {
+          message: `Unknown service ${service}. Supported services are: push, datasync`,
+        };
     }
 
     cmd.registerObserver(this);

--- a/src/cmds/service-cmds/service-bind.ts
+++ b/src/cmds/service-cmds/service-bind.ts
@@ -10,6 +10,9 @@ import {
 } from '../../utils/KubeClient/commands/Observer';
 import { ora } from '../../utils/spinner/OraSingleton';
 import { Spinner } from '../../utils/spinner';
+import { KubeCommand } from '../../utils/KubeClient/KubeClient';
+import { AgKubeDataSyncBindingCommand } from '../../utils/KubeClient/commands/AgKubeDataSyncBindingCommand';
+import { AbstractKubeCommand } from '../../utils/KubeClient/commands/AbstractKubeCommand';
 
 /**
  * This class implements the 'app init <appname>' command.
@@ -70,7 +73,20 @@ class ServiceBindCliCommand extends AbstractNamespaceScopedCommand
       }
     }
 
-    const cmd = new AgKubePushBindingCommand(namespace, appname, conf);
+    let cmd: AbstractKubeCommand;
+
+    switch (service) {
+      case 'push':
+        cmd = new AgKubePushBindingCommand(namespace, appname, conf);
+        break;
+      case 'datasync':
+        cmd = new AgKubeDataSyncBindingCommand(
+          namespace,
+          appname,
+          JSON.parse(conf),
+        );
+    }
+
     cmd.registerObserver(this);
 
     return await KubeClient.getInstance().execute(cmd);

--- a/src/cmds/service-cmds/service-bind.ts
+++ b/src/cmds/service-cmds/service-bind.ts
@@ -1,0 +1,52 @@
+import { Arguments, Argv } from 'yargs';
+import { AbstractNamespaceScopedCommand, expose } from '../command-interface';
+import { KubeClient } from '../../utils/KubeClient';
+import { AgKubePushBindingCommand } from '../../utils/KubeClient/commands/AgKubePushBindingCommand';
+
+/**
+ * This class implements the 'app init <appname>' command.
+ * Its role is to create a new workspace initialised with the specified application name, so that it can be later pushed to the cluster.
+ */
+class ServiceBindCliCommand extends AbstractNamespaceScopedCommand {
+  constructor() {
+    super('bind', 'Binds a service to an app');
+    this.handler = this.handler.bind(this);
+  }
+
+  protected initCli(yargs: Argv): Argv<any> {
+    return yargs
+      .option('appName', {
+        required: true,
+        alias: 'a',
+        type: 'string',
+        describe: 'The name of the app to be bound',
+        nargs: 1,
+      })
+      .option('service', {
+        required: true,
+        alias: 's',
+        type: 'string',
+        describe: 'The service to be bound',
+        nargs: 1,
+      })
+      .option('conf', {
+        alias: 'c',
+        type: 'string',
+        describe: 'The service configuration',
+        nargs: 1,
+      });
+  }
+
+  public handler = async (yargs: Arguments): Promise<void> => {
+    const name: string = yargs.appName as string;
+    const namespace: string =
+      (yargs.namespace as string) ||
+      KubeClient.getInstance().getCurrentNamespace();
+    const res = await KubeClient.getInstance().execute(
+      new AgKubePushBindingCommand(namespace, name, ''),
+    );
+    console.log(res);
+  };
+}
+
+expose(new ServiceBindCliCommand(), module);

--- a/src/cmds/service-cmds/service-bind.ts
+++ b/src/cmds/service-cmds/service-bind.ts
@@ -2,12 +2,21 @@ import { Arguments, Argv } from 'yargs';
 import { AbstractNamespaceScopedCommand, expose } from '../command-interface';
 import { KubeClient } from '../../utils/KubeClient';
 import { AgKubePushBindingCommand } from '../../utils/KubeClient/commands/AgKubePushBindingCommand';
+import { ValidatorFactory } from './validators/ValidatorFactory';
+import {
+  Message,
+  MESSAGE_TYPE,
+  Observer,
+} from '../../utils/KubeClient/commands/Observer';
+import { ora } from '../../utils/spinner/OraSingleton';
+import { Spinner } from '../../utils/spinner';
 
 /**
  * This class implements the 'app init <appname>' command.
  * Its role is to create a new workspace initialised with the specified application name, so that it can be later pushed to the cluster.
  */
-class ServiceBindCliCommand extends AbstractNamespaceScopedCommand {
+class ServiceBindCliCommand extends AbstractNamespaceScopedCommand
+  implements Observer {
   constructor() {
     super('bind', 'Binds a service to an app');
     this.handler = this.handler.bind(this);
@@ -37,16 +46,65 @@ class ServiceBindCliCommand extends AbstractNamespaceScopedCommand {
       });
   }
 
+  @Spinner({
+    pre: 'Binding service to the mobileapp',
+    post: 'Service bound to the mobileapp',
+    fail: 'Error binding service to the mobileapp: %s',
+    swallow: true,
+  })
+  private async bindService(
+    namespace: string,
+    appname: string,
+    service: string,
+    conf: string,
+  ) {
+    // Validate the configuration
+    // FIXME: check that the passed in configuration is a JSON file
+    const validator = ValidatorFactory.create(service);
+    if (validator) {
+      const validationRes = validator.validate(JSON.parse(conf || '{}'));
+      if (!validationRes.valid) {
+        throw {
+          message: validationRes.message,
+        };
+      }
+    }
+
+    const cmd = new AgKubePushBindingCommand(namespace, appname, conf);
+    cmd.registerObserver(this);
+
+    return await KubeClient.getInstance().execute(cmd);
+  }
+
   public handler = async (yargs: Arguments): Promise<void> => {
     const name: string = yargs.appName as string;
     const namespace: string =
       (yargs.namespace as string) ||
       KubeClient.getInstance().getCurrentNamespace();
-    const res = await KubeClient.getInstance().execute(
-      new AgKubePushBindingCommand(namespace, name, yargs.conf as string),
+
+    await this.bindService(
+      namespace,
+      name,
+      yargs.service as string,
+      yargs.conf as string,
     );
-    console.log(res);
   };
+
+  receiveNotification(message: Message) {
+    switch (message.type) {
+      case MESSAGE_TYPE.INFO:
+        ora.info(message.message);
+        break;
+      case MESSAGE_TYPE.PROGRESS:
+        ora.start(message.message);
+        break;
+      case MESSAGE_TYPE.SUCCESS:
+        ora.succeed(message.message);
+        break;
+      case MESSAGE_TYPE.ERROR:
+        ora.fail(message.message);
+    }
+  }
 }
 
 expose(new ServiceBindCliCommand(), module);

--- a/src/cmds/service-cmds/validators/ValidatorFactory.ts
+++ b/src/cmds/service-cmds/validators/ValidatorFactory.ts
@@ -1,0 +1,13 @@
+import { Validator } from 'json-data-validator';
+import { conf as pushValidatorConf } from './push-bind-validator-conf';
+
+export class ValidatorFactory {
+  static create(serviceType: string): Validator {
+    switch (serviceType) {
+      case 'push':
+        return new Validator(pushValidatorConf);
+      default:
+        return null;
+    }
+  }
+}

--- a/src/cmds/service-cmds/validators/ValidatorFactory.ts
+++ b/src/cmds/service-cmds/validators/ValidatorFactory.ts
@@ -1,11 +1,33 @@
+import * as fsExtra from 'fs-extra';
 import { Validator } from 'json-data-validator';
 import { conf as pushValidatorConf } from './push-bind-validator-conf';
+import { conf as datasyncValidatorConf } from './datasync-bind-validator-conf';
 
 export class ValidatorFactory {
+  private static readonly HOME: string = require('os').homedir() + '/.ag';
+
   static create(serviceType: string): Validator {
+    // check if a custom validation has been put into the .ag folder
+    const customServiceValidatorConf = `${ValidatorFactory.HOME}/${serviceType}-validator.json`;
+    if (fsExtra.existsSync(customServiceValidatorConf)) {
+      try {
+        const conf = fsExtra.readJsonSync(customServiceValidatorConf);
+        return new Validator(conf);
+      } catch (error) {
+        throw {
+          message:
+            `Invalid custom validator configuration provided for ${serviceType}: ` +
+            error.message,
+          error,
+        };
+      }
+    }
+
     switch (serviceType) {
       case 'push':
         return new Validator(pushValidatorConf);
+      case 'datasync':
+        return new Validator(datasyncValidatorConf);
       default:
         return null;
     }

--- a/src/cmds/service-cmds/validators/datasync-bind-validator-conf.ts
+++ b/src/cmds/service-cmds/validators/datasync-bind-validator-conf.ts
@@ -1,0 +1,20 @@
+import { ValidatorConfig } from 'json-data-validator';
+
+export const conf: ValidatorConfig = {
+  ruleSets: [
+    {
+      fields: {
+        syncServerUrl: [
+          {
+            type: 'VALID_URL',
+          },
+        ],
+        graphqlEndpoint: [
+          {
+            type: 'VALID_URL_PATH',
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/src/cmds/service-cmds/validators/push-bind-validator-conf.ts
+++ b/src/cmds/service-cmds/validators/push-bind-validator-conf.ts
@@ -1,0 +1,55 @@
+import { ValidatorConfig } from 'json-data-validator';
+
+export const conf: ValidatorConfig = {
+  ruleSets: [
+    {
+      fields: {
+        variant: [
+          {
+            type: 'REQUIRED',
+            errorMessage:
+              'Bad service configuration - variant field is required',
+          },
+          {
+            type: 'COMPOSITE',
+            algorithm: 'any',
+            errorMessage: `Bad service configuration - variant can be either 'ios' or 'android'`,
+            subRules: [
+              {
+                type: 'EXACT_VALUE',
+                value: 'android',
+              },
+              {
+                type: 'EXACT_VALUE',
+                value: 'ios',
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      constraints: [
+        {
+          type: 'FIELD_VALUE',
+          path: 'variant',
+          value: 'android',
+        },
+      ],
+      fields: {
+        serverKey: [
+          {
+            type: 'REQUIRED',
+            errorMessage: 'Bad service configuration - serverKey is required',
+          },
+        ],
+        senderId: [
+          {
+            type: 'REQUIRED',
+            errorMessage: 'Bad service configuration - senderId is required',
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/src/utils/KubeClient/commands/AbstractKubeCommand.ts
+++ b/src/utils/KubeClient/commands/AbstractKubeCommand.ts
@@ -1,7 +1,10 @@
 import { KubeConfig } from '@kubernetes/client-node';
 import { KubeCommand } from '../KubeClient';
+import { Observable } from './Observable';
+import { Message, Observer } from './Observer';
 
-export abstract class AbstractKubeCommand implements KubeCommand {
+export abstract class AbstractKubeCommand implements KubeCommand, Observable {
+  protected readonly observers: Observer[] = [];
   private readonly kubeConfig: KubeConfig = new KubeConfig();
 
   protected constructor() {
@@ -20,4 +23,19 @@ export abstract class AbstractKubeCommand implements KubeCommand {
   protected getKubeConfig = () => this.kubeConfig;
 
   abstract async execute(kube: any): Promise<any>;
+
+  readonly registerObserver = (observer: Observer) => {
+    this.observers.push(observer);
+  };
+
+  readonly removeObserver = (observer: Observer) => {
+    const observerIndex = this.observers.indexOf(observer);
+    this.observers.splice(observerIndex, 1);
+  };
+
+  public readonly notify = (message: Message) => {
+    this.observers.forEach((observer: Observer) =>
+      observer.receiveNotification(message),
+    );
+  };
 }

--- a/src/utils/KubeClient/commands/AgKubeDataSyncBindingCommand.ts
+++ b/src/utils/KubeClient/commands/AgKubeDataSyncBindingCommand.ts
@@ -56,5 +56,5 @@ export class AgKubeDataSyncBindingCommand extends AbstractKubeCommand {
         data: this.conf,
       },
     });
-  }
+  };
 }

--- a/src/utils/KubeClient/commands/AgKubeDataSyncBindingCommand.ts
+++ b/src/utils/KubeClient/commands/AgKubeDataSyncBindingCommand.ts
@@ -1,0 +1,60 @@
+import { AbstractKubeCommand } from './AbstractKubeCommand';
+import { KubeClient } from '../KubeClient';
+import { AgKubePullCommand } from './AgKubePullCommand';
+
+export class AgKubeDataSyncBindingCommand extends AbstractKubeCommand {
+  private readonly app: string;
+  private readonly namespace: string;
+  private readonly conf: { [key: string]: string | number };
+
+  constructor(
+    namespace: string,
+    appname: string,
+    conf: { [key: string]: string | number },
+  ) {
+    super();
+    this.app = appname;
+    this.namespace = namespace || this.getCurrentNamespace();
+    this.conf = conf;
+  }
+
+  private async pullMobileApp() {
+    try {
+      return await KubeClient.getInstance().execute(
+        new AgKubePullCommand(this.app, this.namespace),
+      );
+    } catch (error) {
+      throw {
+        message: `Unable to pull application ${this.app} from namespace ${this.namespace}: ${error.message}`,
+        error,
+      };
+    }
+  }
+
+  execute = async (kube: any): Promise<any> => {
+    const mobileApp = (await this.pullMobileApp()).body;
+
+    const spec = { ...this.conf };
+    delete spec.variant;
+
+    return await kube.api.v1.namespace(this.namespace).configmaps.post({
+      body: {
+        apiVersion: 'v1',
+        kind: 'ConfigMap',
+        metadata: {
+          name: `${this.app}-data-sync-binding`,
+          ownerReferences: [
+            {
+              apiVersion: mobileApp.apiVersion,
+              kind: mobileApp.kind,
+              blockOwnerDeletion: false,
+              name: mobileApp.metadata.name,
+              uid: mobileApp.metadata.uid,
+            },
+          ],
+        },
+        data: this.conf,
+      },
+    });
+  }
+}

--- a/src/utils/KubeClient/commands/AgKubePullCommand.ts
+++ b/src/utils/KubeClient/commands/AgKubePullCommand.ts
@@ -1,5 +1,4 @@
 import { AbstractKubeCommand } from './AbstractKubeCommand';
-import { MobileApp } from '../../../model/MobileApp';
 
 export class AgKubePullCommand extends AbstractKubeCommand {
   private readonly app: string;

--- a/src/utils/KubeClient/commands/AgKubePushBindingCommand.ts
+++ b/src/utils/KubeClient/commands/AgKubePushBindingCommand.ts
@@ -1,5 +1,6 @@
 import { AbstractKubeCommand } from './AbstractKubeCommand';
 import { AgKubePushServiceBinderFactory } from './push-binders/AgKubePushServiceBinderFactory';
+import { Observer } from './Observer';
 
 export class AgKubePushBindingCommand extends AbstractKubeCommand {
   private readonly app: string;
@@ -14,10 +15,16 @@ export class AgKubePushBindingCommand extends AbstractKubeCommand {
   }
 
   execute = async (kube: any): Promise<any> => {
-    return await AgKubePushServiceBinderFactory.create(
+    const delegate = AgKubePushServiceBinderFactory.create(
       this.namespace,
       this.app,
       this.conf,
-    ).execute(kube);
+    );
+
+    this.observers.forEach((observer: Observer) =>
+      delegate.registerObserver(observer),
+    );
+
+    return delegate.execute(kube);
   };
 }

--- a/src/utils/KubeClient/commands/AgKubePushBindingCommand.ts
+++ b/src/utils/KubeClient/commands/AgKubePushBindingCommand.ts
@@ -1,0 +1,98 @@
+import { AbstractKubeCommand } from './AbstractKubeCommand';
+import { KubeClient } from '../KubeClient';
+import { AgKubePullCommand } from './AgKubePullCommand';
+import { poll } from '../../polling/polling';
+
+export class AgKubePushBindingCommand extends AbstractKubeCommand {
+  private readonly app: string;
+  private readonly namespace: string;
+  private readonly conf: string;
+
+  constructor(namespace: string, appname: string, conf: string) {
+    super();
+    this.app = appname;
+    this.namespace = namespace || this.getCurrentNamespace();
+    this.conf = conf;
+  }
+
+  private async createPushApplication(kube: any, owner: any): Promise<any> {
+    try {
+      return await kube.apis['push.aerogear.org'].v1alpha1
+        .namespace(this.namespace)
+        .pushapplication.post({
+          body: {
+            apiVersion: 'push.aerogear.org/v1alpha1',
+            kind: 'PushApplication',
+            metadata: {
+              name: `${this.app}`,
+              ownerReferences: [
+                {
+                  apiVersion: owner.apiVersion,
+                  kind: owner.kind,
+                  blockOwnerDeletion: false,
+                  name: owner.metadata.name,
+                  uid: owner.metadata.uid,
+                },
+              ],
+            },
+            spec: {
+              description: 'MDC Push Application',
+            },
+          },
+        });
+    } catch (error) {
+      // Looks like the push application is not there.
+      // Let's try to create it and then retry this.
+      console.log('error', error);
+    }
+  }
+
+  private async getPushApplication(kube: any, owner: any): Promise<any> {
+    try {
+      const pushApp = await kube.apis['push.aerogear.org'].v1alpha1
+        .namespace(this.namespace)
+        .pushapplication(this.app)
+        .get();
+      // if (!(pushApp.body.status && pushApp.body.status.pushApplicationId)) {
+      //   console.log('App is there but is not ready. Retrying....');
+      //   return await this.getPushApplication(kube, owner);
+      // }
+      return pushApp;
+    } catch (error) {
+      // Looks like the push application is not there.
+      // Let's try to create it and then retry this.
+      await this.createPushApplication(kube, owner);
+      return await this.getPushApplication(kube, owner);
+    }
+  }
+
+  private async pullMobileApp() {
+    try {
+      return await KubeClient.getInstance().execute(
+        new AgKubePullCommand(this.app, this.namespace),
+      );
+    } catch (error) {
+      throw {
+        message: `Unable to pull application ${this.app} from namespace ${this.namespace}: ${error.message}`,
+        error,
+      };
+    }
+  }
+
+  execute = async (kube: any): Promise<any> => {
+    console.log({ app: this.app, namespace: this.namespace });
+    const mobileApp = (await this.pullMobileApp()).body;
+    console.log(mobileApp);
+    const pushApp = await poll(
+      async () => await this.getPushApplication(kube, mobileApp),
+      (pushApp: any) =>
+        !!(pushApp.body.status && pushApp.body.status.pushApplicationId),
+      1000,
+      10000,
+      'Timeout waiting for a pushApplicationId to be assigned to the newly created app',
+    );
+    // We now have the push application. We can now create the variant.
+
+    return pushApp;
+  };
+}

--- a/src/utils/KubeClient/commands/AgKubePushBindingCommand.ts
+++ b/src/utils/KubeClient/commands/AgKubePushBindingCommand.ts
@@ -1,7 +1,5 @@
 import { AbstractKubeCommand } from './AbstractKubeCommand';
-import { KubeClient } from '../KubeClient';
-import { AgKubePullCommand } from './AgKubePullCommand';
-import { poll } from '../../polling/polling';
+import { AgKubePushServiceBinderFactory } from './push-binders/AgKubePushServiceBinderFactory';
 
 export class AgKubePushBindingCommand extends AbstractKubeCommand {
   private readonly app: string;
@@ -12,118 +10,14 @@ export class AgKubePushBindingCommand extends AbstractKubeCommand {
     super();
     this.app = appname;
     this.namespace = namespace || this.getCurrentNamespace();
-    console.log({conf});
-    this.conf = JSON.parse(conf);
-  }
-
-  private async createPushApplication(kube: any, owner: any): Promise<any> {
-    try {
-      return await kube.apis['push.aerogear.org'].v1alpha1
-        .namespace(this.namespace)
-        .pushapplication.post({
-          body: {
-            apiVersion: 'push.aerogear.org/v1alpha1',
-            kind: 'PushApplication',
-            metadata: {
-              name: `${this.app}`,
-              ownerReferences: [
-                {
-                  apiVersion: owner.apiVersion,
-                  kind: owner.kind,
-                  blockOwnerDeletion: false,
-                  name: owner.metadata.name,
-                  uid: owner.metadata.uid,
-                },
-              ],
-            },
-            spec: {
-              description: 'MDC Push Application',
-            },
-          },
-        });
-    } catch (error) {
-      console.log('error', error);
-    }
-  }
-
-  private async createAndroidVariant(
-    kube: any,
-    owner: any,
-    pushApp: any,
-    conf: any,
-  ) {
-    const spec = { ...conf };
-    delete spec.variant;
-
-    return await kube.apis['push.aerogear.org'].v1alpha1
-      .namespace(this.namespace)
-      .androidvariant.post({
-        body: {
-          apiVersion: 'push.aerogear.org/v1alpha1',
-          kind: 'AndroidVariant',
-          metadata: {
-            name: `${this.app}-android-ups-variant`,
-            ownerReferences: [{
-                apiVersion: owner.apiVersion,
-                kind: owner.kind,
-                blockOwnerDeletion: false,
-                name: owner.metadata.name,
-                uid: owner.metadata.uid,
-              },
-            ],
-          },
-          spec: {
-            description: 'UPS Android Variant',
-            pushApplicationId: pushApp.body.status.pushApplicationId,
-            ...spec,
-          },
-        },
-      });
-  }
-
-  private async getPushApplication(kube: any, owner: any): Promise<any> {
-    try {
-      const pushApp = await kube.apis['push.aerogear.org'].v1alpha1
-        .namespace(this.namespace)
-        .pushapplication(this.app)
-        .get();
-      return pushApp;
-    } catch (error) {
-      // Looks like the push application is not there.
-      // Let's try to create it and then retry this.
-      await this.createPushApplication(kube, owner);
-      return await this.getPushApplication(kube, owner);
-    }
-  }
-
-  private async pullMobileApp() {
-    try {
-      return await KubeClient.getInstance().execute(
-        new AgKubePullCommand(this.app, this.namespace),
-      );
-    } catch (error) {
-      throw {
-        message: `Unable to pull application ${this.app} from namespace ${this.namespace}: ${error.message}`,
-        error,
-      };
-    }
+    this.conf = conf;
   }
 
   execute = async (kube: any): Promise<any> => {
-    console.log({ app: this.app, namespace: this.namespace });
-    const mobileApp = (await this.pullMobileApp()).body;
-    console.log(mobileApp);
-    const pushApp = await poll(
-      async () => await this.getPushApplication(kube, mobileApp),
-      (pushApp: any) =>
-        !!(pushApp.body.status && pushApp.body.status.pushApplicationId),
-      1000,
-      10000,
-      'Timeout waiting for a pushApplicationId to be assigned to the newly created app',
-    );
-    // We now have the push application. We can now create the variant.
-    return await this.createAndroidVariant(kube, mobileApp, pushApp, this.conf);
-    // TODO: we should now update the mobileapp with the new bound services. For the moment we will rely to the MDC
-    // server.js to update it.
+    return await AgKubePushServiceBinderFactory.create(
+      this.namespace,
+      this.app,
+      this.conf,
+    ).execute(kube);
   };
 }

--- a/src/utils/KubeClient/commands/Observable.ts
+++ b/src/utils/KubeClient/commands/Observable.ts
@@ -1,0 +1,7 @@
+import { Message, Observer } from './Observer';
+
+export interface Observable {
+  registerObserver(observer: Observer);
+  removeObserver(observer: Observer);
+  notify(message: Message);
+}

--- a/src/utils/KubeClient/commands/Observer.ts
+++ b/src/utils/KubeClient/commands/Observer.ts
@@ -1,0 +1,74 @@
+import * as util from 'util';
+import { Observable } from './Observable';
+
+export enum MESSAGE_TYPE {
+  PROGRESS,
+  INFO,
+  ERROR,
+  SUCCESS,
+}
+
+export interface Message {
+  type: MESSAGE_TYPE;
+  message: string;
+}
+
+export interface Observer {
+  receiveNotification(message: Message);
+}
+
+interface NotifyMessage {
+  pre: string;
+  post: string;
+  fail: string;
+  swallow?: boolean;
+}
+
+export function Notify({ pre, post, fail, swallow }: NotifyMessage) {
+  return (
+    target: Object,
+    key: string,
+    descriptor: TypedPropertyDescriptor<any>,
+  ) => {
+    const originalMethod = descriptor.value;
+    descriptor.value = function(...args: any[]) {
+      const observer: Observable = this;
+      try {
+        observer.notify({
+          type: MESSAGE_TYPE.PROGRESS,
+          message: pre,
+        });
+        const ret = originalMethod.apply(this, args);
+        if (ret && ret.then) {
+          // it is a promise
+          return ret
+            .then((value: any) => {
+              observer.notify({
+                type: MESSAGE_TYPE.SUCCESS,
+                message: post,
+              });
+              return value;
+            })
+            .catch((error: Error) => {
+              observer.notify({
+                type: MESSAGE_TYPE.ERROR,
+                message: util.format(fail, error.message),
+              });
+              throw error;
+            });
+        }
+        observer.notify({
+          type: MESSAGE_TYPE.SUCCESS,
+          message: post,
+        });
+        return ret;
+      } catch (error) {
+        observer.notify({
+          type: MESSAGE_TYPE.ERROR,
+          message: util.format(fail, error.message),
+        });
+      }
+    };
+    return descriptor;
+  };
+}

--- a/src/utils/KubeClient/commands/push-binders/AgAbstractKubePushServiceBinder.ts
+++ b/src/utils/KubeClient/commands/push-binders/AgAbstractKubePushServiceBinder.ts
@@ -1,0 +1,100 @@
+import { AbstractKubeCommand } from '../AbstractKubeCommand';
+import { poll } from '../../../polling/polling';
+import { KubeClient } from '../../KubeClient';
+import { AgKubePullCommand } from '../AgKubePullCommand';
+
+export abstract class AgAbstractKubePushServiceBinder extends AbstractKubeCommand {
+  protected readonly app: string;
+  protected readonly namespace: string;
+  protected readonly conf: any;
+
+  public constructor(namespace: string, appname: string, conf: string) {
+    super();
+    this.app = appname;
+    this.namespace = namespace || this.getCurrentNamespace();
+    this.conf = JSON.parse(conf);
+  }
+
+  private async pullMobileApp() {
+    try {
+      return await KubeClient.getInstance().execute(
+        new AgKubePullCommand(this.app, this.namespace),
+      );
+    } catch (error) {
+      throw {
+        message: `Unable to pull application ${this.app} from namespace ${this.namespace}: ${error.message}`,
+        error,
+      };
+    }
+  }
+
+  private async createPushApplication(kube: any, mobileApp: any): Promise<any> {
+    return await kube.apis['push.aerogear.org'].v1alpha1
+      .namespace(this.namespace)
+      .pushapplication.post({
+        body: {
+          apiVersion: 'push.aerogear.org/v1alpha1',
+          kind: 'PushApplication',
+          metadata: {
+            name: `${this.app}`,
+            ownerReferences: [
+              {
+                apiVersion: mobileApp.apiVersion,
+                kind: mobileApp.kind,
+                blockOwnerDeletion: false,
+                name: mobileApp.metadata.name,
+                uid: mobileApp.metadata.uid,
+              },
+            ],
+          },
+          spec: {
+            description: 'MDC Push Application',
+          },
+        },
+      });
+  }
+
+  private async getOrCreatePushApplication(
+    kube: any,
+    mobileApp: any,
+  ): Promise<any> {
+    try {
+      return await kube.apis['push.aerogear.org'].v1alpha1
+        .namespace(this.namespace)
+        .pushapplication(this.app)
+        .get();
+    } catch (error) {
+      // Looks like the push application is not there.
+      // Let's try to create it and then retry this.
+      await this.createPushApplication(kube, mobileApp);
+      return await this.getOrCreatePushApplication(kube, mobileApp);
+    }
+  }
+
+  private async getPushApplication(kube: any, mobileApp: any): Promise<any> {
+    return await poll(
+      async () => await this.getOrCreatePushApplication(kube, mobileApp),
+      (pushApp: any) =>
+        !!(pushApp.body.status && pushApp.body.status.pushApplicationId),
+      1000,
+      10000,
+      'Timeout waiting for a pushApplicationId to be assigned to the newly created app',
+    );
+  }
+
+  protected abstract async createVariant(
+    kube: any,
+    mobileApp: any,
+    pushApplication: any,
+    conf: any,
+  ): Promise<any>;
+
+  execute = async (kube: any): Promise<any> => {
+    const mobileApp = (await this.pullMobileApp()).body;
+    const pushApp = await this.getPushApplication(kube, mobileApp);
+    // We now have the push application. We can now create the variant.
+    return await this.createVariant(kube, mobileApp, pushApp, this.conf);
+    // TODO: we should now update the mobileapp with the new bound services. For the moment we will rely to the MDC
+    // server.js to update it.
+  };
+}

--- a/src/utils/KubeClient/commands/push-binders/AgAbstractKubePushServiceBinder.ts
+++ b/src/utils/KubeClient/commands/push-binders/AgAbstractKubePushServiceBinder.ts
@@ -2,6 +2,7 @@ import { AbstractKubeCommand } from '../AbstractKubeCommand';
 import { poll } from '../../../polling/polling';
 import { KubeClient } from '../../KubeClient';
 import { AgKubePullCommand } from '../AgKubePullCommand';
+import { Notify } from '../Observer';
 
 export abstract class AgAbstractKubePushServiceBinder extends AbstractKubeCommand {
   protected readonly app: string;
@@ -15,6 +16,11 @@ export abstract class AgAbstractKubePushServiceBinder extends AbstractKubeComman
     this.conf = JSON.parse(conf);
   }
 
+  @Notify({
+    pre: 'Pulling mobile app from the cluster',
+    post: 'Mobile app pulled successfully',
+    fail: 'Error pulling mobile app: %s',
+  })
   private async pullMobileApp() {
     try {
       return await KubeClient.getInstance().execute(
@@ -28,6 +34,11 @@ export abstract class AgAbstractKubePushServiceBinder extends AbstractKubeComman
     }
   }
 
+  @Notify({
+    pre: 'Creating new push application',
+    post: 'Push application created successfully',
+    fail: 'Error creating mobile app: %s',
+  })
   private async createPushApplication(kube: any, mobileApp: any): Promise<any> {
     return await kube.apis['push.aerogear.org'].v1alpha1
       .namespace(this.namespace)
@@ -71,6 +82,11 @@ export abstract class AgAbstractKubePushServiceBinder extends AbstractKubeComman
     }
   }
 
+  @Notify({
+    pre: 'Getting push application',
+    post: 'Push application pulled successfully',
+    fail: 'Error getting the push application: %s',
+  })
   private async getPushApplication(kube: any, mobileApp: any): Promise<any> {
     return await poll(
       async () => await this.getOrCreatePushApplication(kube, mobileApp),

--- a/src/utils/KubeClient/commands/push-binders/AgKubeAndroidPushServiceBinder.ts
+++ b/src/utils/KubeClient/commands/push-binders/AgKubeAndroidPushServiceBinder.ts
@@ -1,12 +1,53 @@
 import { AgAbstractKubePushServiceBinder } from './AgAbstractKubePushServiceBinder';
+import { ValidatorConfig, Validator } from 'json-data-validator';
+import { Notify } from '../Observer';
 
 export class AgKubeAndroidPushServiceBinder extends AgAbstractKubePushServiceBinder {
+  private getConfigValidationRules(): ValidatorConfig {
+    return {
+      ruleSets: [
+        {
+          fields: {
+            variant: [
+              {
+                type: 'EXACT_VALUE',
+                value: 'android',
+              },
+            ],
+            serverKey: [
+              {
+                type: 'REQUIRED',
+              },
+            ],
+            senderId: [
+              {
+                type: 'REQUIRED',
+              },
+            ],
+          },
+        },
+      ],
+    };
+  }
+
+  @Notify({
+    pre: 'Creating new Android Variant',
+    post: 'Android variant created successfully',
+    fail: 'Failed creating new android variant: %s',
+  })
   protected async createVariant(
     kube: any,
     mobileApp: any,
     pushApplication: any,
     conf: any,
   ): Promise<any> {
+    const validator: Validator = new Validator(this.getConfigValidationRules());
+    const validationRes = validator.validate(conf);
+    if (!validationRes.valid) {
+      console.log(validationRes.message);
+      return;
+    }
+
     const spec = { ...conf };
     delete spec.variant;
 

--- a/src/utils/KubeClient/commands/push-binders/AgKubeAndroidPushServiceBinder.ts
+++ b/src/utils/KubeClient/commands/push-binders/AgKubeAndroidPushServiceBinder.ts
@@ -1,0 +1,39 @@
+import { AgAbstractKubePushServiceBinder } from './AgAbstractKubePushServiceBinder';
+
+export class AgKubeAndroidPushServiceBinder extends AgAbstractKubePushServiceBinder {
+  protected async createVariant(
+    kube: any,
+    mobileApp: any,
+    pushApplication: any,
+    conf: any,
+  ): Promise<any> {
+    const spec = { ...conf };
+    delete spec.variant;
+
+    return await kube.apis['push.aerogear.org'].v1alpha1
+      .namespace(this.namespace)
+      .androidvariant.post({
+        body: {
+          apiVersion: 'push.aerogear.org/v1alpha1',
+          kind: 'AndroidVariant',
+          metadata: {
+            name: `${this.app}-android-ups-variant`,
+            ownerReferences: [
+              {
+                apiVersion: mobileApp.apiVersion,
+                kind: mobileApp.kind,
+                blockOwnerDeletion: false,
+                name: mobileApp.metadata.name,
+                uid: mobileApp.metadata.uid,
+              },
+            ],
+          },
+          spec: {
+            description: 'UPS Android Variant',
+            pushApplicationId: pushApplication.body.status.pushApplicationId,
+            ...spec,
+          },
+        },
+      });
+  }
+}

--- a/src/utils/KubeClient/commands/push-binders/AgKubeIOSPushServiceBinder.ts
+++ b/src/utils/KubeClient/commands/push-binders/AgKubeIOSPushServiceBinder.ts
@@ -1,0 +1,39 @@
+import { AgAbstractKubePushServiceBinder } from './AgAbstractKubePushServiceBinder';
+
+export class AgKubeIOSPushServiceBinder extends AgAbstractKubePushServiceBinder {
+  protected async createVariant(
+    kube: any,
+    mobileApp: any,
+    pushApplication: any,
+    conf: any,
+  ): Promise<any> {
+    const spec = { ...conf };
+    delete spec.variant;
+
+    return await kube.apis['push.aerogear.org'].v1alpha1
+      .namespace(this.namespace)
+      .iosvariant.post({
+        body: {
+          apiVersion: 'push.aerogear.org/v1alpha1',
+          kind: 'IOSVariant',
+          metadata: {
+            name: `${this.app}-ios-ups-variant`,
+            ownerReferences: [
+              {
+                apiVersion: mobileApp.apiVersion,
+                kind: mobileApp.kind,
+                blockOwnerDeletion: false,
+                name: mobileApp.metadata.name,
+                uid: mobileApp.metadata.uid,
+              },
+            ],
+          },
+          spec: {
+            description: 'UPS iOS Variant',
+            pushApplicationId: pushApplication.body.status.pushApplicationId,
+            ...spec,
+          },
+        },
+      });
+  }
+}

--- a/src/utils/KubeClient/commands/push-binders/AgKubePushServiceBinderFactory.ts
+++ b/src/utils/KubeClient/commands/push-binders/AgKubePushServiceBinderFactory.ts
@@ -1,0 +1,21 @@
+import { AbstractKubeCommand } from '../AbstractKubeCommand';
+import { AgKubeAndroidPushServiceBinder } from './AgKubeAndroidPushServiceBinder';
+
+export class AgKubePushServiceBinderFactory {
+  private constructor() {}
+
+  public static create(
+    namespace: string,
+    appName: string,
+    conf: string,
+  ): AbstractKubeCommand {
+    const configuration = JSON.parse(conf);
+
+    switch (configuration.variant) {
+      case 'android':
+        return new AgKubeAndroidPushServiceBinder(namespace, appName, conf);
+      default:
+        throw { message: `Unknown variant type: '${configuration.variant}'` };
+    }
+  }
+}

--- a/src/utils/polling/polling.ts
+++ b/src/utils/polling/polling.ts
@@ -1,0 +1,27 @@
+async function asyncWait(delay: number = 3000): Promise<void> {
+  return new Promise((resolve: () => void) => {
+    setTimeout(() => resolve(), delay);
+  });
+}
+
+export async function poll(
+  f: () => any,
+  cond: (o: any) => boolean,
+  delay: number = 1000,
+  timeout: number = 10000,
+  timeoutMessage: string = 'Timeout'
+): Promise<any> {
+  const start: number = new Date().getTime();
+  let res = await f();
+  while (!cond(res)) {
+    await asyncWait(delay);
+    res = await f();
+    if (timeout !== 0 && new Date().getTime() - start > timeout) {
+      throw {
+        message: timeoutMessage,
+      };
+    }
+  }
+
+  return res;
+}

--- a/src/utils/polling/polling.ts
+++ b/src/utils/polling/polling.ts
@@ -9,7 +9,7 @@ export async function poll(
   cond: (o: any) => boolean,
   delay: number = 1000,
   timeout: number = 10000,
-  timeoutMessage: string = 'Timeout'
+  timeoutMessage: string = 'Timeout',
 ): Promise<any> {
   const start: number = new Date().getTime();
   let res = await f();

--- a/src/utils/spinner/OraSingleton.ts
+++ b/src/utils/spinner/OraSingleton.ts
@@ -1,0 +1,4 @@
+import { Ora } from 'ora';
+import * as oraFactory from 'ora';
+
+export const ora: Ora = oraFactory();

--- a/src/utils/spinner/Spinner.ts
+++ b/src/utils/spinner/Spinner.ts
@@ -1,6 +1,6 @@
 import * as util from 'util';
-import * as ora from 'ora';
 import { Ora } from 'ora';
+import { ora } from './OraSingleton';
 
 /**
  * A log handler will receive the messages and will log them accordingly.
@@ -43,7 +43,7 @@ export interface SpinnerMessage {
 class SpinnerImpl implements SpinnerHandler {
   private static INSTANCE: SpinnerImpl;
 
-  private readonly spinner: Ora = ora();
+  private readonly spinner: Ora = ora;
   private constructor() {}
 
   public static getInstance() {

--- a/src/workspace/impl/FSWorkspace.ts
+++ b/src/workspace/impl/FSWorkspace.ts
@@ -11,7 +11,7 @@ export class FSWorkspace implements WorkspaceInterface {
   private readonly path: string;
 
   constructor() {
-    this.path = require('os').homedir() + '/.ag';
+    this.path = require('os').homedir() + '/.ag/workspace';
     if (!this.exists()) {
       this.init(false);
     }


### PR DESCRIPTION
# Motivation
ISSUE: [AEROGEAR-9796](https://issues.jboss.org/browse/AEROGEAR-9796)

This PR is based on changes from #8 

Datasync service can be bound with a command similar too:

```bash
kubectl ag service bind -a [your app] -s datasync -c '{ "syncServerUrl": "http://localhost", "graphqlEndpoint": "/graphql" }'
```

Custom validation for the `datasync` configuration can be put in the file `$HOME/.ag/datasync-validator.json`

An example content for such file could be:
```json
{
  "ruleSets": [
    {
       "fields": {
         "syncServerUrl": [{
            "type": "VALID_URL"
         }],
         "graphqlEndpoint": [{
            "type": "VALID_URL_PATH"
         }]
       }
    }
  ]
}
```

## Known issues

Currently works directly on the cluster. Ability to work only offline (into workspace folder) will be added in a future PR.